### PR TITLE
Fix: `org-roam-ql--expand-link` `:or` case comparison is off-by-1

### DIFF
--- a/org-roam-ql.el
+++ b/org-roam-ql.el
@@ -453,7 +453,7 @@ backlinks"
          (--filter
           (pcase combine
             (:and (= (cadr it) query-nodes-count))
-            (:or (> (cadr it) 1))
+            (:or (>= (cadr it) 1))
             (_ (user-error "Keyword :combine should be :and or :or; got %s" combine))))
          (--map (org-roam-node-from-id (car it))))))
 


### PR DESCRIPTION
Fix #7 