### PR TITLE
Fix timestamp comparison

### DIFF
--- a/org-roam-ql.el
+++ b/org-roam-ql.el
@@ -625,7 +625,8 @@ backlinks"
   "Convert TIME to ts.
 This uses `org-time-string-to-seconds' or `time-convert' based on the type."
   (cond
-   ((stringp time) (org-time-string-to-seconds time))
+   ((stringp time) (org-roam-ql--time-convert-to-ts
+                    (encode-time (parse-time-string time))))
    ((and (not (null time)) (listp time)) (time-convert time 'integer))
    (t (user-error "Unknown value for `time'"))))
 


### PR DESCRIPTION
Fix #16 

The bug is in the first timestamp parsing, i.e `org-roam-ql--time-convert-to-ts`.

org-roam saves scheduled/deadline timestamp in ISO8601 format, see [org-roam-db-get-scheduled-time](https://github.com/org-roam/org-roam/blob/046822b512ffecdee7d110f73dd3a511802ca590/org-roam-db.el#L307). And it turns out that `org-time-string-to-seconds`, used by `org-roam-ql--time-convert-to-ts`, does not handle ISO8601 timestamp with `HH:MM:SS` correctly (I'm very surprised when I found this out ...).

All these s-exps evaluate to the same value:
```elisp
(org-time-string-to-seconds "2025-04-10T05:00:00")
(org-time-string-to-seconds "2025-04-10T04:00:00")
(org-time-string-to-seconds "2025-04-10")
```

After applying the fix, the test given in the related issue passes.